### PR TITLE
Standardize .github/dependabot.yml configuration to group AWS Deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,33 +6,43 @@ registries:
     username: x-access-token
     password: "${{secrets.RUBYGEMS_SERVER_GITHUB_TOKEN}}"
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-    time: '10:00'
-    timezone: America/Los_Angeles
-  pull-request-branch-name:
-    separator: "-"
-  commit-message:
-    prefix: "🔧 "
-    prefix-development: "🔧 "
-    include: scope
-  open-pull-requests-limit: 10
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-    time: '10:00'
-    timezone: America/Los_Angeles
-  pull-request-branch-name:
-    separator: "-"
-  commit-message:
-    prefix: "⬆️ "
-    prefix-development: "⬆️ "
-    include: scope
-  open-pull-requests-limit: 10
-  registries:
-  - github-octocat
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+      timezone: America/Los_Angeles
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "🔧 "
+      prefix-development: "🔧 "
+      include: scope
+    open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+      timezone: America/Los_Angeles
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "⬆️ "
+      prefix-development: "⬆️ "
+      include: scope
+    open-pull-requests-limit: 20
+    registries:
+      - github-octocat
+    groups:
+      aws-sdk-go-v2:
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - github.com/aws/aws-sdk-go-v2*
+        update-types:
+          - major
+          - minor
+          - patch


### PR DESCRIPTION
This batch change updates the `.github/dependabot.yml` file to a standardized configuration.

[_Created by Sourcegraph batch change `promiseofcake/group-aws-sdk-updates-for-go`._](https://chime.sourcegraph.com/users/promiseofcake/batch-changes/group-aws-sdk-updates-for-go)