### PR TITLE
[CI-328] Pin Ubuntu version for GitHub Actions workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-# see https://github.com/marketplace/actions/dependabot-auto-merge
+# To learn more about Dependabot configuration at Chime, visit: http://go/dependabot-configuration
 name: "Dependabot Automerge"
 
 on: pull_request_target
@@ -6,13 +6,13 @@ on: pull_request_target
 jobs:
   auto-merge:
     if: startsWith(github.head_ref, 'dependabot')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Check if auto merges/deploys are allowed
-      - name:  Auto Merges/deploys allowed?
+      - name: Auto Merges/deploys allowed?
         uses: 1debit/pr-auto-merge-action@v1
       # Check if PR can be auto-approved
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE }} # 1debitops token


### PR DESCRIPTION
[GitHub is updating the version of Ubuntu](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/) used by the `ubuntu-latest` tag, including removing some packages. What's worse is that we don't have an exact date, but it's supposed to happen sometime between Dec 5 and Jan 17.

This could potentially result in difficult to predict failures to workflows, especially difficult to test if they run only on the `main` branch and not as part of pull requests on feature branches.

To prevent that from happening, we want to get ahead of that update and upgrade the version to `24.04` right now for all "standard" GitHub workflows, incl.:
  * Mergebot (`check-can-merge.yml`) - additional changes in this file may be present to align it with the latest template version
  * Dependabot auto-approve (`dependabot-auto-approve.yml`) - additional changes in this file may be present to align it with the latest template version
  * Stale PR checks (`stale.yml` or `pr-cleanup.yml`)

For all other workflows, the change locks in the version to `22.04` (which is what `ubuntu-latest` is set to right now) so teams can individually update them to `24.04`, verifying that everything continues to work as expected.

Please make sure to create tickets in your backlog to schedule that work in before EOQ1 2025.

Note that we no longer recommend using the floating `ubuntu-latest` tag going forward.

[_Created by Sourcegraph batch change `maciej-chime/GithubWorkflowsPinUbuntuVersion`._](https://chime.sourcegraph.com/users/maciej-chime/batch-changes/GithubWorkflowsPinUbuntuVersion)