### PR TITLE
[CI-342] Stop using 1debitops user for Dependabot workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 #
 # Anyone can edit
 #
-# This allows the @1debitops user to approve PRs and automerge them.
-# If you add someone below, you must also add @1debitops on the same line,
+# This allows the @chime-dependency-bot user to approve PRs and automerge them.
+# If you add someone below, you must also add @chime-dependency-bot on the same line,
 # otherwise automerge will break.
 # If you wish to not restrict reviewers for these files, but want to get
 # notified on Dependabot PRs, add a "reviewers" section to your dependabot.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,39 @@
+# To learn more about Dependabot configuration at Chime, visit: http://go/dependabot-configuration
 version: 2
 registries:
   github-octocat:
     type: git
     url: https://github.com
     username: x-access-token
-    password: "${{secrets.RUBYGEMS_SERVER_GITHUB_TOKEN}}"
+    password: "${{secrets.DEPENDABOT_GITHUB_TOKEN}}"
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-    time: '10:00'
-    timezone: America/Los_Angeles
-  pull-request-branch-name:
-    separator: "-"
-  commit-message:
-    prefix: "🔧 "
-    prefix-development: "🔧 "
-    include: scope
-  open-pull-requests-limit: 10
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-    time: '10:00'
-    timezone: America/Los_Angeles
-  pull-request-branch-name:
-    separator: "-"
-  commit-message:
-    prefix: "⬆️ "
-    prefix-development: "⬆️ "
-    include: scope
-  open-pull-requests-limit: 10
-  registries:
-  - github-octocat
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "10:00"
+      timezone: America/Los_Angeles
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "🔧 "
+      prefix-development: "🔧 "
+      include: scope
+    open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "10:00"
+      timezone: America/Los_Angeles
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "⬆️ "
+      prefix-development: "⬆️ "
+      include: scope
+    open-pull-requests-limit: 10
+    registries:
+      - github-octocat

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE }} # 1debitops token
+          github-token: "${{ secrets.DEPENDABOT_AUTO_MERGE_GITHUB_TOKEN }}" # chime-dependency-bot user token
           config: .github/dependabot-auto-merge.config.yml
+          command: "squash and merge"


### PR DESCRIPTION
This replaces the usage of tokens associated with the @1debitops external collaborator with tokens associated with the @chime-dependency-bot user.

Along the way we're also making a few smaller improvements:
* Adding links to internal documentation for Dependabot
* Consistently formatting the Dependabot configuration

[_Created by Sourcegraph batch change `maciej-chime/SwitchDependabotToChimeDependencyBotUser`._](https://chime.sourcegraph.com/users/maciej-chime/batch-changes/SwitchDependabotToChimeDependencyBotUser)